### PR TITLE
Initial policy, scope, and reporting endpoints

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -1,0 +1,61 @@
+# Vulnerability Disclosure Policy
+
+As part of a US Government agency, [GSA's Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public's information, including financial and personal information, from unwarranted disclosure.
+
+We want security researchers to feel comfortable reporting vulnerabilities they've discovered, as set out in this policy, so that we can fix them and keep our information safe.
+
+This policy describes **what systems and types of research** are covered under this policy, **how to send us** vulnerability reports, and **how long** we ask security researchers to wait before publicly disclosing vulnerabilities.
+
+## Guidelines
+
+We require that you:
+
+* Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction or manipulation of data.
+
+* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to "pivot" to other systems. Once you’ve established that a vulnerability exists, or encountered any of the sensitive data outlined below, you must stop your test and notify us immediately.
+
+* Keep confidential any information about discovered vulnerabilities for 90 calendar days after you have notified us.
+
+## Scope
+
+This policy applies to the following systems:
+
+* [`vote.gov`](https://vote.gov)
+* [`analytics.usa.gov`](https://analytics.usa.gov)
+* [`calc.gsa.gov`](https://calc.gsa.gov)
+* [`micropurchase.18f.gov`](https://micropurchase.18f.gov)
+* [`18f.gsa.gov`](https://18f.gsa.gov)
+
+**Any services not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. If you aren’t sure whether a system or endpoint is in scope or not, contact us at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) before starting your research.
+
+**The following test types are not authorized:**
+
+* User interface bugs or typos.
+* Network denial of service (DoS or DDoS) tests.
+* Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing.
+
+If you encounter any of the below on our systems while testing within the scope of this policy, **stop your test and notify us at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) immediately**:
+
+* Personally identifiable information
+* Financial information. (e.g. credit card or bank account numbers)
+* Proprietary information or trade secrets of companies of any party
+
+## Authorization
+
+If you make a good faith effort to comply with this policy during your security research, we will consider your research to be authorized, will work with you to understand and resolve the issue quickly, and GSA will not initiate or recommend legal action related to your research.
+
+## Reporting a vulnerability
+
+We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`] or [through this reporting form](#). Reports may be submitted anonymously.
+
+Reports should include:
+
+* Description of the location and potential impact of the vulnerability.
+
+* A detailed description of the steps required to reproduce the vulnerability. Proof of concept (POC) scripts, screenshots, and screen captures are all helpful. Please use extreme care to properly label and protect any exploit code.
+
+* Any technical information and related materials we would need to reproduce the issue.
+
+Please keep your vulnerability reports current by sending us any new information as it becomes available.
+
+We may share your vulnerability reports with [US-CERT](https://www.us-cert.gov/ais), as well as any affected vendors or open source projects.

--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -46,7 +46,7 @@ If you make a good faith effort to comply with this policy during your security 
 
 ## Reporting a vulnerability
 
-We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`] or [through this reporting form](#). Reports may be submitted anonymously.
+We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`] or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously.
 
 Reports should include:
 

--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -46,7 +46,7 @@ If you make a good faith effort to comply with this policy during your security 
 
 ## Reporting a vulnerability
 
-We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`] or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously.
+We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously.
 
 Reports should include:
 


### PR DESCRIPTION
This is TTS' vulnerability disclosure policy, with a first pass at systems in scope and the right reporting endpoints (email address, and a Google Form).

It's rendered in Markdown, and will also be rendered at 18f.gsa.gov/vulnerability-disclosure-policy, similar to how our [open source policy](https://18f.gsa.gov/open-source-policy/) appears.

I included the systems I knew to safely be in scope from previous discussions. We can easily add more. For now, changes made to this document should then be manually replicated to 18f.gsa.gov.