### PR TITLE
Update for Non-GPG and TLS Alternative

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -56,6 +56,8 @@ Reports should include:
 
 * Any technical information and related materials we would need to reproduce the issue.
 
+**Note: At this time, we do not currently support GPG-encrypted emails for vulnerability reports. For particularly sensitive information, please contact via an TLS-encrypted form.**
+
 Please keep your vulnerability reports current by sending us any new information as it becomes available.
 
 We may share your vulnerability reports with [US-CERT](https://www.us-cert.gov/ais), as well as any affected vendors or open source projects.

--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -46,7 +46,7 @@ If you make a good faith effort to comply with this policy during your security 
 
 ## Reporting a vulnerability
 
-We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously.
+We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously. **Note: We do not support GPG-encrypted emails.** For particularly sensitive information, use the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
 
 Reports should include:
 
@@ -55,8 +55,6 @@ Reports should include:
 * A detailed description of the steps required to reproduce the vulnerability. Proof of concept (POC) scripts, screenshots, and screen captures are all helpful. Please use extreme care to properly label and protect any exploit code.
 
 * Any technical information and related materials we would need to reproduce the issue.
-
-**Note: At this time, we do not currently support GPG-encrypted emails for vulnerability reports. For particularly sensitive information, please contact via an TLS-encrypted form.**
 
 Please keep your vulnerability reports current by sending us any new information as it becomes available.
 

--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -46,7 +46,7 @@ If you make a good faith effort to comply with this policy during your security 
 
 ## Reporting a vulnerability
 
-We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously. **Note: We do not support GPG-encrypted emails.** For particularly sensitive information, use the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
+We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously. **Note: We do not support PGP-encrypted emails.** For particularly sensitive information, use the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
 
 Reports should include:
 


### PR DESCRIPTION
Will need the actual URL inserted I assume - helps to address; https://github.com/18F/vulnerability-disclosure-policy/issues/4