### PR TITLE
Minor capitalization and punctuation fixes

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -1,8 +1,8 @@
 # Vulnerability Disclosure Policy
 
-As part of a U.S. government agency, [GSA’s Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public’s information, including financial and personal information, from unwarranted disclosure.
+As part of a U.S. government agency, [GSA's Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public's information, including financial and personal information, from unwarranted disclosure.
 
-We want security researchers to feel comfortable reporting vulnerabilities they’ve discovered, as set out in this policy, so that we can fix them and keep our information safe.
+We want security researchers to feel comfortable reporting vulnerabilities they've discovered, as set out in this policy, so that we can fix them and keep our information safe.
 
 This policy describes **what systems and types of research** are covered under this policy, **how to send us** vulnerability reports, and **how long** we ask security researchers to wait before publicly disclosing vulnerabilities.
 
@@ -12,7 +12,7 @@ We require that you:
 
 * Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction or manipulation of data.
 
-* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to “pivot” to other systems. Once you’ve established that a vulnerability exists, or encountered any of the sensitive data outlined below, you must stop your test and notify us immediately.
+* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to "pivot" to other systems. Once you've established that a vulnerability exists, or encountered any of the sensitive data outlined below, you must stop your test and notify us immediately.
 
 * Keep confidential any information about discovered vulnerabilities for 90 calendar days after you have notified us.
 
@@ -26,7 +26,7 @@ This policy applies to the following systems:
 * [`micropurchase.18f.gov`](https://micropurchase.18f.gov)
 * [`18f.gsa.gov`](https://18f.gsa.gov)
 
-**Any services not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. If you aren’t sure whether a system or endpoint is in scope or not, contact us at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) before starting your research.
+**Any services not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. If you aren't sure whether a system or endpoint is in scope or not, contact us at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) before starting your research.
 
 **The following test types are not authorized:**
 

--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -1,8 +1,8 @@
 # Vulnerability Disclosure Policy
 
-As part of a US Government agency, [GSA's Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public's information, including financial and personal information, from unwarranted disclosure.
+As part of a U.S. government agency, [GSA’s Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public’s information, including financial and personal information, from unwarranted disclosure.
 
-We want security researchers to feel comfortable reporting vulnerabilities they've discovered, as set out in this policy, so that we can fix them and keep our information safe.
+We want security researchers to feel comfortable reporting vulnerabilities they’ve discovered, as set out in this policy, so that we can fix them and keep our information safe.
 
 This policy describes **what systems and types of research** are covered under this policy, **how to send us** vulnerability reports, and **how long** we ask security researchers to wait before publicly disclosing vulnerabilities.
 
@@ -12,7 +12,7 @@ We require that you:
 
 * Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction or manipulation of data.
 
-* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to "pivot" to other systems. Once you’ve established that a vulnerability exists, or encountered any of the sensitive data outlined below, you must stop your test and notify us immediately.
+* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to “pivot” to other systems. Once you’ve established that a vulnerability exists, or encountered any of the sensitive data outlined below, you must stop your test and notify us immediately.
 
 * Keep confidential any information about discovered vulnerabilities for 90 calendar days after you have notified us.
 
@@ -37,7 +37,7 @@ This policy applies to the following systems:
 If you encounter any of the below on our systems while testing within the scope of this policy, **stop your test and notify us at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) immediately**:
 
 * Personally identifiable information
-* Financial information. (e.g. credit card or bank account numbers)
+* Financial information (e.g. credit card or bank account numbers)
 * Proprietary information or trade secrets of companies of any party
 
 ## Authorization


### PR DESCRIPTION
Changes `US Government` to `U.S. government` (per 18F style), corrects several quotation marks, and removes one inconsistent period in a list.