### PR TITLE
Tweaks the section about 3rd party info

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -34,7 +34,7 @@ This policy applies to the following systems:
 * Network denial of service (DoS or DDoS) tests.
 * Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing.
 
-If you encounter any of the below on our systems while testing within the scope of this policy, **stop your test and notify us at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) immediately**:
+If you encounter a vulnerability that discloses any of the below on our systems while testing within the scope of this policy, **stop your test and notify us at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) immediately**:
 
 * Personally identifiable information
 * Financial information (e.g. credit card or bank account numbers)


### PR DESCRIPTION
As this was written, it was a bit weird because I assume some (most?) of your systems have PII, financial info, and proprietary info. Encountering it could be fairly normal -- for example, I might see my own PII, but that doesn't mean I should stop doing my vulnerability test.

The important thing is *does the vulnerability* allow access to *more* of it.