### PR TITLE
Elaborate on our use of Google Forms

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -46,7 +46,7 @@ If you make a good faith effort to comply with this policy during your security 
 
 ### Reporting a vulnerability
 
-We accept and discuss vulnerability reports at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously.
+We accept and discuss vulnerability reports at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). (GSA uses Google Apps internally, so either contact method will go into the same system.) Reports may be submitted anonymously.
 
 Reports should include:
 


### PR DESCRIPTION
We've gotten a couple of inquiries about our use of Google Forms since releasing this policy. It's not obvious to people that this is a GSA system (with GSA and the USG's guarantees on privacy/security/records, etc.).

This mentions explicitly that GSA uses Google Apps and that both email and this form flow into the same system.