### PR TITLE
GSA was never defined and removed from TTS link

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -1,6 +1,6 @@
 ### Vulnerability disclosure policy
 
-As part of a U.S. government agency, [GSA's Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public's information, including financial and personal information, from unwarranted disclosure.
+As part of a U.S. government agency, the General Services Administration (GSA)'s [Technology Transformation Service (TTS)](http://gsa.gov/tts) takes seriously our responsibility to protect the public's information, including financial and personal information, from unwarranted disclosure.
 
 We want security researchers to feel comfortable reporting vulnerabilities they've discovered, as set out in this policy, so that we can fix them and keep our information safe.
 


### PR DESCRIPTION
The acronym GSA was used throughout the document, but never previously defined, so I wrote out the entire name at the first mention. Also, since this is a TTS-only policy and not a GSA-wide policy, I thought it prudent to take GSA out of the link to TTS's page.