### PR TITLE
Note scope of cloud.gov policy

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -20,7 +20,7 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) (all customer applications are excluded from scope)
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: account.fr.cloud.gov, api.fr.cloud.gov, ci.fr.cloud.gov, community.fr.cloud.gov, dashboard.fr.cloud.gov, login.fr.cloud.gov, logs.fr.cloud.gov, metrics.fr.cloud.gov. Any other subdomain of cloud.gov and all customer applications are excluded from this policy.
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)
 * [`calc.gsa.gov`](https://calc.gsa.gov)

--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -20,7 +20,7 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and all subdomains
+* [`cloud.gov`](https://cloud.gov) (all customer applications are excluded from scope)
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)
 * [`calc.gsa.gov`](https://calc.gsa.gov)


### PR DESCRIPTION
This is important for the time being; we'll come up with a list of cloud.gov subdomains to include.