### PR TITLE
Add subdomains of login.gov, make surrounding language consistent

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -20,8 +20,8 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy.
-* [`login.gov`](https://login.gov)
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov, including all customer applications, is excluded from this policy.
+* [`login.gov`](https://login.gov) and the following subdomains: `demo.login.gov`, `int.login.gov`, `dev.login.gov`, `qa.login.gov`, `pt.login.gov`, `staging.login.gov`, `dm.login.gov`, `prod.login.gov`, `dashboard.demo.login.gov`, `dashboard.qa.login.gov`, `dashboard.dev.login.gov`. Any other subdomain of login.gov is excluded from this policy.
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)
 * [`calc.gsa.gov`](https://calc.gsa.gov)


### PR DESCRIPTION
This adds a set of subdomains specified by the login.gov team, and tweaks the cloud.gov language to be consistent in phrasing.

cc @kimberbat @mzia