### PR TITLE
Clearly exclude all cloud.gov customer apps

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -20,7 +20,7 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov, including all customer applications, is excluded from this policy.
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy.
 * [`login.gov`](https://login.gov) and the following subdomains: `demo.login.gov`, `int.login.gov`, `dev.login.gov`, `qa.login.gov`, `pt.login.gov`, `staging.login.gov`, `dm.login.gov`, `prod.login.gov`, `dashboard.demo.login.gov`, `dashboard.qa.login.gov`, `dashboard.dev.login.gov`. Any other subdomain of login.gov is excluded from this policy.
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)


### PR DESCRIPTION
This is a followup to the PR at https://github.com/18F/vulnerability-disclosure-policy/pull/19 - it reverts the small change to the cloud.gov section, since it's important to be very clear that _all_ customer applications on cloud.gov are out of scope (including customer applications on custom domains as well as customer applications on *.cloud.gov domains).