### PR TITLE
More clarity for cloud.gov customer apps

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -20,7 +20,7 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy.
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded).
 * [`login.gov`](https://login.gov) and the following subdomains: `demo.login.gov`, `int.login.gov`, `dev.login.gov`, `qa.login.gov`, `pt.login.gov`, `staging.login.gov`, `dm.login.gov`, `prod.login.gov`, `dashboard.demo.login.gov`, `dashboard.qa.login.gov`, `dashboard.dev.login.gov`. Any other subdomain of login.gov is excluded from this policy.
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)


### PR DESCRIPTION
Adding "(`*.app.cloud.gov` is specifically excluded)" because it may not be clear to readers that this is a customer application domain.