### PR TITLE
Add links to report via HackerOne

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -34,13 +34,15 @@ This policy applies to the following systems:
 
 **Any services not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. Additionally, vulnerabilities found in non-federal systems from our vendors fall outside of this policy's scope and should be reported directly to the vendor according to their disclosure policy (if any). If you aren't sure whether a system or endpoint is in scope or not, contact us at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) before starting your research.
 
+A subset of these systems may be eligable for bounties. Check our [program page on HackerOne](https://hackerone.com/tts) for the current list of bounty-eligable systems.
+
 **The following test types are not authorized:**
 
 * User interface bugs or typos.
 * Network denial of service (DoS or DDoS) tests.
 * Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing.
 
-If you encounter any of the below on our systems while testing within the scope of this policy, **stop your test and notify us at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) immediately**:
+If you encounter any of the below on our systems while testing within the scope of this policy, **stop your test and notify us](#reporting) immediately**:
 
 * Personally identifiable information
 * Financial information (e.g. credit card or bank account numbers)
@@ -50,9 +52,12 @@ If you encounter any of the below on our systems while testing within the scope 
 
 If you make a good faith effort to comply with this policy during your security research, we will consider your research to be authorized, will work with you to understand and resolve the issue quickly, and GSA will not initiate or recommend legal action related to your research.
 
+<a name="reporting"></a>
 ### Reporting a vulnerability
 
-We accept and discuss vulnerability reports at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). (GSA uses Google Apps internally, so either contact method will go into the same system.) Reports may be submitted anonymously. **Note: We do not support PGP-encrypted emails.** For particularly sensitive information, use the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
+We accept and discuss vulnerability reports [on HackerOne](https://hackerone.com/tts), or via email at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov), or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).(GSA uses Google Apps internally, so either contact method will go into the same system.) Reports may be submitted anonymously. **Note: We do not support PGP-encrypted emails.** For particularly sensitive information, use the [HackerOne](https://hackerone.com/tts) or the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
+
+We prefer reports via HackerOne, but will respond to reports through any of the above channels. Note, however, that only reports submitted via HackerOne will be eligable for bounties, where applicable.
 
 Reports should include:
 

--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -34,7 +34,7 @@ This policy applies to the following systems:
 
 **Any services not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. Additionally, vulnerabilities found in non-federal systems from our vendors fall outside of this policy's scope and should be reported directly to the vendor according to their disclosure policy (if any). If you aren't sure whether a system or endpoint is in scope or not, contact us at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) before starting your research.
 
-A subset of these systems may be eligable for bounties. Check our [program page on HackerOne](https://hackerone.com/tts) for the current list of bounty-eligable systems.
+A subset of these systems may be eligible for bounties. Check our [program page on HackerOne](https://hackerone.com/tts) for the current list of bounty-eligible systems.
 
 **The following test types are not authorized:**
 
@@ -42,7 +42,7 @@ A subset of these systems may be eligable for bounties. Check our [program page 
 * Network denial of service (DoS or DDoS) tests.
 * Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing.
 
-If you encounter any of the below on our systems while testing within the scope of this policy, **stop your test and notify us](#reporting) immediately**:
+If you encounter any of the below on our systems while testing within the scope of this policy, **[stop your test and notify us](#reporting-a-vulnerability) immediately**:
 
 * Personally identifiable information
 * Financial information (e.g. credit card or bank account numbers)
@@ -52,8 +52,7 @@ If you encounter any of the below on our systems while testing within the scope 
 
 If you make a good faith effort to comply with this policy during your security research, we will consider your research to be authorized, will work with you to understand and resolve the issue quickly, and GSA will not initiate or recommend legal action related to your research.
 
-<a name="reporting"></a>
-### Reporting a vulnerability
+\### Reporting a vulnerability
 
 We accept and discuss vulnerability reports [on HackerOne](https://hackerone.com/tts), or via email at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov), or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).(GSA uses Google Apps internally, so either contact method will go into the same system.) Reports may be submitted anonymously. **Note: We do not support PGP-encrypted emails.** For particularly sensitive information, use the [HackerOne](https://hackerone.com/tts) or the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
 

--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -54,7 +54,7 @@ If you make a good faith effort to comply with this policy during your security 
 
 \### Reporting a vulnerability
 
-We accept and discuss vulnerability reports [on HackerOne](https://hackerone.com/tts), or via email at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov), or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).(GSA uses Google Apps internally, so either contact method will go into the same system.) Reports may be submitted anonymously. **Note: We do not support PGP-encrypted emails.** For particularly sensitive information, use the [HackerOne](https://hackerone.com/tts) or the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
+We accept and discuss vulnerability reports [on HackerOne](https://hackerone.com/tts), or via email at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov), or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). (GSA uses Google Apps internally, so either contact method will go into the same system.) Reports may be submitted anonymously. **Note: We do not support PGP-encrypted emails.** For particularly sensitive information, use the [HackerOne](https://hackerone.com/tts) or the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
 
 We prefer reports via HackerOne, but will respond to reports through any of the above channels. Note, however, that only reports submitted via HackerOne will be eligable for bounties, where applicable.
 


### PR DESCRIPTION
Update to point people towards HackerOne for reporting.

Also make sure to indicate that only reports via H1 are eligible to be paid.