### PR TITLE
updated policy for Login.gov

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -24,7 +24,7 @@ This policy applies to the following systems:
 * [`federalist.18f.gov`](https://federalist.18f.gov)
 * [`federalist-docs.18f.gov`](https://federalist-docs.18f.gov)
 * [`federalist-proxy.app.cloud.gov`](https://federalist-proxy.app.cloud.gov)
-* [`login.gov`](https://login.gov) and the following subdomains: `demo.login.gov`, `int.login.gov`, `dev.login.gov`, `qa.login.gov`, `pt.login.gov`, `staging.login.gov`, `dm.login.gov`, `prod.login.gov`, `dashboard.demo.login.gov`, `dashboard.qa.login.gov`, `dashboard.dev.login.gov`. Any other subdomain of login.gov is excluded from this policy.
+* [`login.gov`](https://login.gov) and the following subdomains: `secure.login.gov`, `www.login.gov`. Any other subdomain of login.gov is excluded from this policy.
 * [`data.gov`](https://data.gov) and the following subdomains: `www.data.gov`, `federation.data.gov`, `sdg.data.gov`, `labs.data.gov`, `catalog.data.gov`, `inventory.data.gov`, `static.data.gov`, `admin-catalog-bsp.data.gov`, `manage.data.gov`. Any other subdomains of data.gov are excluded from this policy (`api.data.gov` is specifically excluded).
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)


### PR DESCRIPTION
removes non-prod subdomains and clarifies primary domains in-scope.