### PR TITLE
Add idp.fr.cloud.gov to cloud.gov vdp scope

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -20,7 +20,7 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded, except for `federalist-proxy.app.cloud.gov`).
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `idp.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded, except for `federalist-proxy.app.cloud.gov`).
 * [`federalist.18f.gov`](https://federalist.18f.gov)
 * [`federalist-docs.18f.gov`](https://federalist-docs.18f.gov)
 * [`federalist-proxy.app.cloud.gov`](https://federalist-proxy.app.cloud.gov)


### PR DESCRIPTION
`idp.fr.cloud.gov` is utilized for user authentication to cloud.gov, we should explicitly add it to scope for vuln disclosure.
cc @brittag 