### PR TITLE
Remove micropurchase.18f.gov from scope

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -29,7 +29,6 @@ This policy applies to the following systems:
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)
 * [`calc.gsa.gov`](https://calc.gsa.gov)
-* [`micropurchase.18f.gov`](https://micropurchase.18f.gov)
 * [`18f.gsa.gov`](https://18f.gsa.gov)
 
 **Any services not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. Additionally, vulnerabilities found in non-federal systems from our vendors fall outside of this policy's scope and should be reported directly to the vendor according to their disclosure policy (if any). If you aren't sure whether a system or endpoint is in scope or not, contact us at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) before starting your research.


### PR DESCRIPTION
It's now a static site hosted on Federalist, so it doesn't feel like including it fits the goals of this policy any longer.