### PR TITLE
Update in-scope domains list for cloud.gov

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -20,7 +20,7 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `idp.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded, except for `federalist-proxy.app.cloud.gov`).
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `admin.fr.cloud.gov`, `alertmanager.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `diagrams.fr.cloud.gov`, `grafana.fr.cloud.gov`, `idp.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `logs-platform.fr.cloud.gov`, `nessus.fr.cloud.gov`, `opslogin.fr.cloud.gov`, `prometheus.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded, except for `federalist-proxy.app.cloud.gov`).
 * [`federalist.18f.gov`](https://federalist.18f.gov)
 * [`federalist-docs.18f.gov`](https://federalist-docs.18f.gov)
 * [`federalist-proxy.app.cloud.gov`](https://federalist-proxy.app.cloud.gov)


### PR DESCRIPTION
This removes a few domains that we aren't using anymore, and it adds new ones. This uses our ConMon Checklist (https://github.com/18F/cg-product/blob/master/ConMonChecklist.md) plus `diagrams.fr.cloud.gov` and `nessus.fr.cloud.gov`.