### PR TITLE
Expand login.gov scope, clarify reporting wording

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -24,7 +24,7 @@ This policy applies to the following systems:
 * [`federalist.18f.gov`](https://federalist.18f.gov)
 * [`federalist-docs.18f.gov`](https://federalist-docs.18f.gov)
 * [`federalist-proxy.app.cloud.gov`](https://federalist-proxy.app.cloud.gov)
-* [`login.gov`](https://login.gov) and the following subdomains: `secure.login.gov`, `www.login.gov`. Any other subdomain of login.gov is excluded from this policy.
+* [`login.gov`](https://login.gov) and all subdomains of `login.gov`.
 * [`data.gov`](https://data.gov) and the following subdomains: `www.data.gov`, `api.data.gov`, `federation.data.gov`, `sdg.data.gov`, `labs.data.gov`, `catalog.data.gov`, `inventory.data.gov`, `static.data.gov`, `admin-catalog-bsp.data.gov`, `manage.data.gov`. Any other subdomains of data.gov are excluded from this policy.
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)
@@ -53,7 +53,7 @@ If you make a good faith effort to comply with this policy during your security 
 
 ### Reporting a vulnerability
 
-We accept and discuss vulnerability reports [on HackerOne](https://hackerone.com/tts), or via email at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov), or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). (GSA uses Google Apps internally, so either contact method will go into the same system.) Reports may be submitted anonymously. **Note: We do not support PGP-encrypted emails.** For particularly sensitive information, use the [HackerOne](https://hackerone.com/tts) or the [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
+We accept and discuss vulnerability reports [on HackerOne](https://hackerone.com/tts), via email at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov), or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). (GSA uses G Suite internally, so either email or Google Forms will go into the same system.) Reports may be submitted anonymously. **Note: We do not support PGP-encrypted emails.** For particularly sensitive information, submit through [our HackerOne program](https://hackerone.com/tts) or our [TLS-encrypted web form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform).
 
 We prefer reports via HackerOne, but will respond to reports through any of the above channels. Note, however, that only reports submitted via HackerOne will be eligible for bounties, where applicable.
 


### PR DESCRIPTION
This expands the VDP scope to all subdomains of login.gov, to match their bounty scope, and clarifies some sentences around our reporting channels.