### PR TITLE
Fewer for countable, less for uncountable nouns

### DIFF
--- a/vulnerability-disclosure-policy.md
+++ b/vulnerability-disclosure-policy.md
@@ -78,7 +78,7 @@ We may share your vulnerability reports with [US-CERT](https://www.us-cert.gov/a
 
 ### Coordinated Disclosure
 
-TTS is committed to patching vulnerabilities within 90 days or less, and disclosing the details of those vulnerabilities when patches are published. We believe that public disclosure of vulnerabilities is an essential part of the vulnerability disclosure process, and that one of the best ways to make software better is to enable everyone to learn from each other's mistakes.
+TTS is committed to patching vulnerabilities within 90 days or fewer, and disclosing the details of those vulnerabilities when patches are published. We believe that public disclosure of vulnerabilities is an essential part of the vulnerability disclosure process, and that one of the best ways to make software better is to enable everyone to learn from each other's mistakes.
 
 At the same time, we believe that disclosure in absence of a readily available patch tends to increase risk rather than reduce it, and so we ask that you refrain from sharing your report with others while we work on our patch. If you believe there are others that should be informed of your report before the patch is available, please let us know so we can make arrangements.
 


### PR DESCRIPTION
More significantly, I think we need to reconsider the 90-day clock. I've had a report that took months to fully patch because the only feasible fix was an infrastructure change that we had to get approved. I think it's fair to ask: "90 days since you last heard from us" to encourage accountability on our part, but a strict 90-day clock from report to fix is not always possible.